### PR TITLE
Entferne buecher.de

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -1,6 +1,6 @@
 ! Title: ASB - Axel Springer Filter List
 ! Expires: 4 days
-! Version: 201903290001
+! Version: 201906220001
 ! Description: Filtert Qualitätsjournalismus aus dem Hause Axel Springer
 ! Homepage: https://tobsa13.github.io/ASB/
 ! Licence: https://github.com/TobsA13/ASB/blob/master/LICENSE.md
@@ -122,7 +122,6 @@
 ||stylebook.de$document
 ||schweizerbank.ch$document
 ||axelspringer.hu$document
-||buecher.de$document
 ||antenne1.de$document
 ||bonial.com$document
 ||stylebistro.com$document

--- a/filterlist_hosts.txt
+++ b/filterlist_hosts.txt
@@ -243,8 +243,6 @@ fe80::1%lo0 localhost
 0.0.0.0 www.schweizerbank.ch
 0.0.0.0 axelspringer.hu
 0.0.0.0 www.axelspringer.hu
-0.0.0.0 buecher.de
-0.0.0.0 www.buecher.de
 0.0.0.0 antenne1.de
 0.0.0.0 www.antenne1.de
 0.0.0.0 bonial.com


### PR DESCRIPTION
Axel Springer ist nicht mehr an buecher.de beteiligt

https://www.axelspringer.com/de/presseinformationen/axel-springer-verkauft-seine-buecher-de-anteile-an-weltbild
https://www.lesen.net/ebook-news/weltbild-uebernimmt-buecher-de-komplett-14166/
https://de.wikipedia.org/wiki/Buecher.de (Siehe Abschnitt "Gesellschafter")