### PR TITLE
Add bike-bild.de

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -58,6 +58,7 @@
 ||belvilla.com$document
 ||beobachter.ch$document
 ||beobachtertv.ch$document
+||bike-bild.de$document
 ||bilanz-magazin.de$document
 ||bild.de$document
 ||blic.rs$document

--- a/filterlist_hosts.txt
+++ b/filterlist_hosts.txt
@@ -115,6 +115,8 @@ fe80::1%lo0 localhost
 0.0.0.0 www.beobachter.ch
 0.0.0.0 beobachtertv.ch
 0.0.0.0 www.beobachtertv.ch
+0.0.0.0 bike-bild.de
+0.0.0.0 www.bike-bild.de
 0.0.0.0 bilanz-magazin.de
 0.0.0.0 www.bilanz-magazin.de
 0.0.0.0 bild.de


### PR DESCRIPTION
From the [impressum](https://www.bike-bild.de/impressum-360811.html):

> Verlag 
> Axel Springer Auto Verlag GmbH 
> Axel-Springer-Platz 1 
> 20350 Hamburg 
> Tel.: 040 34700 
> www.axelspringer.de