### PR TITLE
Localhost redirects removed

### DIFF
--- a/filterlist_hosts.txt
+++ b/filterlist_hosts.txt
@@ -8,13 +8,6 @@
 # GitHub pull requests: https://github.com/TobsA13/ASB/pulls
 
 
-127.0.0.1 localhost
-127.0.0.1 localhost.localdomain
-127.0.0.1 local
-255.255.255.255 broadcasthost
-::1 localhost
-fe80::1%lo0 localhost
-
 0.0.0.0 amiado.com
 0.0.0.0 www.amiado.com
 0.0.0.0 amiadogroup.com


### PR DESCRIPTION
I now need to re-enable .local with a custom rewrite rule so that internal devices work again. localhost etc should not be in an Axel Springer filter list.